### PR TITLE
Fix macOS install script issues

### DIFF
--- a/install_macos.sh
+++ b/install_macos.sh
@@ -133,14 +133,24 @@ EOF
 }
 
 load_service() {
-    launchctl bootout "gui/$UID" "$PLIST_PATH" 2>/dev/null || true
-    launchctl bootstrap "gui/$UID" "$PLIST_PATH"
-    launchctl enable "gui/$UID/${LAUNCH_AGENT_LABEL}"
-    launchctl kickstart -k "gui/$UID/${LAUNCH_AGENT_LABEL}"
+    local label="${LAUNCH_AGENT_LABEL}"
+    local domain="gui/$UID"
+
+    launchctl bootout "${domain}/${label}" 2>/dev/null || true
+
+    if ! launchctl bootstrap "${domain}" "${PLIST_PATH}" 2>/dev/null; then
+        print_error "launchctl bootstrap failed. Try manually: launchctl bootstrap ${domain} ${PLIST_PATH}"
+        return 1
+    fi
+
+    launchctl enable "${domain}/${label}" 2>/dev/null || true
+    launchctl kickstart -k "${domain}/${label}" 2>/dev/null || true
+
+    print_success "LaunchAgent registered and started."
 }
 
 unload_service() {
-    launchctl bootout "gui/$UID" "$PLIST_PATH" 2>/dev/null || true
+    launchctl bootout "gui/$UID/${LAUNCH_AGENT_LABEL}" 2>/dev/null || true
 }
 
 install_program() {


### PR DESCRIPTION
The auto-setup script broke for me, which is not fun. I kept getting this error: `Creating launchd agent... Bootstrap failed: 125: Domain does not support specified` so this should fix it! There is a little bit more error handling in case it breaks again, which should make debugging easier in the future.

Fun fact! On macOS 13+ (Ventura onward), bootstrap gui/$UID plist_path is still often required to initially load the plist into launchd.